### PR TITLE
Don't run on push

### DIFF
--- a/.github/workflows/update-example.yml
+++ b/.github/workflows/update-example.yml
@@ -1,8 +1,6 @@
 name: Update Example Image
 
 on:
-    push:
-        branches: [main]
     schedule:
         # Run every 6 hours
         - cron: '0 */6 * * *'


### PR DESCRIPTION
Because we ran on every push, the actions caught in infinite loop, where one action, pushed to main, and ran another action